### PR TITLE
Fix failing token unit tests

### DIFF
--- a/tests/services/token.service.test.ts
+++ b/tests/services/token.service.test.ts
@@ -58,7 +58,7 @@ describe('Test token.service', () => {
       const validToken: string = getValidToken();
       const req: Request = <Request> <unknown> { query: { token: validToken } };
 
-      const result: TokenPayload = await tokenService.extractTokenPayload(req);
+      const result: TokenPayload = await tokenService.extractTokenPayload(req, true);
 
       expect(awsMock.KMS).toHaveBeenCalledWith({
         apiVersion: '2014-11-01',
@@ -70,9 +70,9 @@ describe('Test token.service', () => {
         CiphertextBlob: Buffer.from(jwtSecret, 'base64'),
       });
       expect(result).toStrictEqual({
-        "atfId": "856090d1-f2dc-4bbc-ad36-8d14382339e0",
-        "endDate": "2020-12-20T23:59:59.000Z",
-        "startDate": "2020-11-23T00:00:00.000Z",
+        atfId: '856090d1-f2dc-4bbc-ad36-8d14382339e0',
+        endDate: '2020-12-20T23:59:59.000Z',
+        startDate: '2020-11-23T00:00:00.000Z',
       });
     });
 
@@ -84,9 +84,9 @@ describe('Test token.service', () => {
       const result: TokenPayload = await tokenService.extractTokenPayload(req, true);
 
       expect(result).toStrictEqual({
-        "atfId": "856090d1-f2dc-4bbc-ad36-8d14382339e0",
-        "endDate": "2020-12-20T23:59:59.000Z",
-        "startDate": "2020-11-23T00:00:00.000Z",
+        atfId: '856090d1-f2dc-4bbc-ad36-8d14382339e0',
+        endDate: '2020-12-20T23:59:59.000Z',
+        startDate: '2020-11-23T00:00:00.000Z',
       });
     });
 
@@ -94,7 +94,7 @@ describe('Test token.service', () => {
       const req: Request = <Request> <unknown> { query: null };
 
       await expect(
-        async () => tokenService.extractTokenPayload(req),
+        async () => tokenService.extractTokenPayload(req, true),
       ).rejects.toThrow(
         new InvalidTokenException(),
       );
@@ -118,7 +118,7 @@ describe('Test token.service', () => {
       const req: Request = <Request> <unknown> { query: { token: invalidToken } };
 
       await expect(
-        async () => tokenService.extractTokenPayload(req),
+        async () => tokenService.extractTokenPayload(req, true),
       ).rejects.toThrow(
         new InvalidTokenException(),
       );
@@ -130,7 +130,7 @@ describe('Test token.service', () => {
       const req: Request = <Request> <unknown> { query: { token: invalidToken } };
 
       await expect(
-        async () => tokenService.extractTokenPayload(req),
+        async () => tokenService.extractTokenPayload(req, true),
       ).rejects.toThrow(
         new InvalidTokenException(),
       );
@@ -138,13 +138,13 @@ describe('Test token.service', () => {
         req, expect.stringContaining('Failed to verify token, error: "sub" is missing'),
       );
     });
- 
+
     it('should throw InvalidTokenException when "startDate" is missing', async () => {
       const invalidToken: string = getStartDateMissingToken();
       const req: Request = <Request> <unknown> { query: { token: invalidToken } };
 
       await expect(
-        async () => tokenService.extractTokenPayload(req),
+        async () => tokenService.extractTokenPayload(req, true),
       ).rejects.toThrow(
         new InvalidTokenException(),
       );
@@ -158,7 +158,7 @@ describe('Test token.service', () => {
       const req: Request = <Request> <unknown> { query: { token: invalidToken } };
 
       await expect(
-        async () => tokenService.extractTokenPayload(req),
+        async () => tokenService.extractTokenPayload(req, true),
       ).rejects.toThrow(
         new InvalidTokenException(),
       );
@@ -176,7 +176,7 @@ describe('Test token.service', () => {
       }));
 
       await expect(
-        async () => tokenService.extractTokenPayload(req),
+        async () => tokenService.extractTokenPayload(req, true),
       ).rejects.toThrow(error);
       expect(logger.warn).toBeCalledWith(
         req, expect.stringContaining('Failed to decrypt JWT_SECRET'),
@@ -240,5 +240,4 @@ describe('Test token.service', () => {
       expect(logger.warn).toHaveBeenCalledWith(req, 'Failed to generate new ATF [atf-id] token');
     });
   });
- 
 });


### PR DESCRIPTION


## Description

Unit tests were failing as the tokens used in unit testing different aspects of the token validation are hardcoded in a fixture file. The tokens had expired back in Dec 2020 which was causing the tests to fail. Fixed by passing an optional flag to the method that will tell it to ignore the expiry date.

Related issue: https://jira.dvsacloud.uk/browse/BL-11940


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
