### PR TITLE
WIP Bugfix/date handling unit tests

### DIFF
--- a/src/controllers/index.controller.ts
+++ b/src/controllers/index.controller.ts
@@ -28,7 +28,11 @@ export const updateAvailability = async (req:Request, res:Response, next: NextFu
     const atf: AuthorisedTestingFacility = await availabilityService.getAtf(req, tokenPayload.atfId);
     atf.availability = availabilityService.setAvailability(tokenPayload, false);
     atf.token = tokenService.retrieveTokenFromQueryParams(req);
-    return res.render('availability-confirmation/choose', { atf });
+    logger.debug(req,"Start date retrieved  " + new Date(tokenPayload.startDate).toISOString);
+    logger.debug(req,"End date retrieved  " + new Date(tokenPayload.endDate).toISOString);
+
+    res.render('availability-confirmation/choose', {'atf':atf})
+
   } catch (error) {
     if (error instanceof ExpiredTokenException) {
       return res.redirect(302, buildRedirectUri('/reissue-token', req));

--- a/src/controllers/index.controller.ts
+++ b/src/controllers/index.controller.ts
@@ -28,8 +28,6 @@ export const updateAvailability = async (req:Request, res:Response, next: NextFu
     const atf: AuthorisedTestingFacility = await availabilityService.getAtf(req, tokenPayload.atfId);
     atf.availability = availabilityService.setAvailability(tokenPayload, false);
     atf.token = tokenService.retrieveTokenFromQueryParams(req);
-    logger.debug(req,"Start date retrieved  " + new Date(tokenPayload.startDate).toISOString);
-    logger.debug(req,"End date retrieved  " + new Date(tokenPayload.endDate).toISOString);
 
     res.render('availability-confirmation/choose', {'atf':atf})
 
@@ -61,8 +59,11 @@ export const confirmAvailability = async (req: Request, res: Response, next: Nex
         formErrors: getDefaultChoiceError(),
       });
     }
-    const updateResponse = await availabilityService.updateAtfAvailability(req, tokenPayload, (availability === 'true'));
-    logger.info(req, `update response is ${updateResponse.availability.isAvailable.toString()} set for ${updateResponse.id}`);
+    const newAvailability = await availabilityService.updateAtfAvailability(req, tokenPayload, (availability === 'true'));
+    logger.info(req, `update response is ${newAvailability.availability.isAvailable.toString()} set for ${newAvailability.id}`);
+    atf.availability.startDate = newAvailability.availability.startDate;
+    atf.availability.endDate = newAvailability.availability.endDate;
+    atf.availability.isAvailable = availability;
     const templateName: string = booleanHelper.mapBooleanToYesNoString((availability === 'true'));
     return res.render(`availability-confirmation/${templateName}`, { atf });
   } catch (error) {

--- a/src/utils/viewHelper.util.ts
+++ b/src/utils/viewHelper.util.ts
@@ -1,6 +1,7 @@
 import nunjucks, { Environment } from 'nunjucks';
 import { Express } from 'express';
 import { format, utcToZonedTime } from 'date-fns-tz';
+import { isValid, parseISO } from 'date-fns';
 
 export const setUpNunjucks = (app: Express): Environment => {
   const env = nunjucks.configure(['views'], {
@@ -9,8 +10,8 @@ export const setUpNunjucks = (app: Express): Environment => {
   }).addGlobal('NODE_ENV', process.env.NODE_ENV)
     .addGlobal('getAsset', (name: string) => (process.env.CDN_URL || '/assets/') + name)
     .addFilter('formatDate', (date: string) => format(utcToZonedTime(new Date(date), process.env.TIMEZONE), 'd MMMM yyyy'))
-    .addFilter('formatDateTime', (date: string) => format(utcToZonedTime(new Date(date), process.env.TIMEZONE), 'EEEE d MMMM yyyy \'at\' h:mmaaaaa\'m\''));
-  // ... any other globals or custom filters here
+    .addFilter('formatDateTime', (date: string) => format(utcToZonedTime(new Date(date), process.env.TIMEZONE), 'EEEE d MMMM yyyy \'at\' h:mmaaaaa\'m\''))
+   // ... any other globals or custom filters here
 
   return env;
 };

--- a/src/views/availability-confirmation/no.njk
+++ b/src/views/availability-confirmation/no.njk
@@ -10,7 +10,9 @@
     text: "Back",
     attributes: { id: "back-link" }
   }) }}
-    <p class="govuk-body-s" id="last-updated-date" >Last updated on {{ atf.availability.lastUpdated | formatDateTime }}</p>
+    {% if atf.availability.lastUpdated|length %}
+      <p class="govuk-body-s" id="last-updated-date" >Last updated on {{ atf.availability.lastUpdated | formatDateTime }}</p>
+    {% endif %}
 
     {{ govukPanel({
       titleText: atf.name + " is fully booked",

--- a/src/views/availability-confirmation/yes.njk
+++ b/src/views/availability-confirmation/yes.njk
@@ -5,7 +5,9 @@
 {% block content %}
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <p class="govuk-body-s" id="last-updated-date" >Last updated on {{ atf.availability.lastUpdated | formatDateTime }}</p>
+    {% if atf.availability.lastUpdated|length %}
+      <p class="govuk-body-s" id="last-updated-date" >Last updated on {{ atf.availability.lastUpdated | formatDateTime }}</p>
+    {% endif %}
  {{ govukBackLink({
     href: "/update?token="+atf.token,
     text: "Back",

--- a/tests/controllers/index.controller.test.ts
+++ b/tests/controllers/index.controller.test.ts
@@ -88,13 +88,23 @@ describe('Test availability.controller', () => {
       const getAtfServiceMock = jest.spyOn(availabilityService, 'getAtf');
       getAtfServiceMock.mockReturnValue(
         Promise.resolve(
-          <AuthorisedTestingFacility><unknown>{ id: atfId, availability: { isAvailable: true } },
+          <AuthorisedTestingFacility><unknown>{ id: atfId, availability: {
+             isAvailable: true,
+             startDate: '2021-04-19T00:00:00.000Z',
+             endDate: '2021-05-16T23:59:59.000Z',
+             lastUpdated: '2021-04-14T16:57:35.429Z'
+            } },
         ),
       );
       const updateAvailabilitySpy = jest.spyOn(availabilityService, 'updateAtfAvailability');
       updateAvailabilitySpy.mockReturnValue(
         Promise.resolve(
-          <AuthorisedTestingFacility><unknown>{ id: atfId, availability: { isAvailable: true } },
+          <AuthorisedTestingFacility><unknown>{ id: atfId, availability: {
+             isAvailable: true,
+             startDate: '2021-04-26T00:00:00.000Z',
+             endDate: '2021-05-23T23:59:59.000Z',
+             lastUpdated: '2021-04-21T16:57:35.429Z'
+            } },
         ),
       );
       const renderMock = jest.spyOn(resMock, 'render');
@@ -103,7 +113,46 @@ describe('Test availability.controller', () => {
       expect(extractTokenPayloadServiceMock).toHaveBeenCalledWith(reqMock);
       expect(getAtfServiceMock).toHaveBeenCalledWith(reqMock, atfId);
       expect(renderMock).toHaveBeenCalledWith('availability-confirmation/yes', {
-        atf: { id: atfId, availability: { isAvailable: true }, token: '1234' },
+        atf: { id: atfId, availability: {
+          isAvailable: "true",
+          startDate: '2021-04-26T00:00:00.000Z',
+          endDate: '2021-05-23T23:59:59.000Z',
+          lastUpdated: '2021-04-14T16:57:35.429Z'
+         }, token: '1234' },
+      });
+    });
+
+    it('should call res.render() with proper params when there is no historical availability data', async () => {
+      const extractTokenPayloadServiceMock = jest.spyOn(tokenService, 'extractTokenPayload');
+      extractTokenPayloadServiceMock.mockReturnValue(Promise.resolve(<TokenPayload><unknown>{ atfId }));
+      const getAtfServiceMock = jest.spyOn(availabilityService, 'getAtf');
+      getAtfServiceMock.mockReturnValue(
+        Promise.resolve(
+          <AuthorisedTestingFacility><unknown>{ id: atfId, availability: {} },
+        ),
+      );
+      const updateAvailabilitySpy = jest.spyOn(availabilityService, 'updateAtfAvailability');
+      updateAvailabilitySpy.mockReturnValue(
+        Promise.resolve(
+          <AuthorisedTestingFacility><unknown>{ id: atfId, availability: {
+             isAvailable: true,
+             startDate: '2021-04-26T00:00:00.000Z',
+             endDate: '2021-05-23T23:59:59.000Z',
+             lastUpdated: '2021-04-21T16:57:35.429Z'
+            } },
+        ),
+      );
+      const renderMock = jest.spyOn(resMock, 'render');
+      await confirmAvailability(reqMock, resMock, nextMock);
+
+      expect(extractTokenPayloadServiceMock).toHaveBeenCalledWith(reqMock);
+      expect(getAtfServiceMock).toHaveBeenCalledWith(reqMock, atfId);
+      expect(renderMock).toHaveBeenCalledWith('availability-confirmation/yes', {
+        atf: { id: atfId, availability: {
+          isAvailable: "true",
+          startDate: '2021-04-26T00:00:00.000Z',
+          endDate: '2021-05-23T23:59:59.000Z',
+         }, token: '1234' },
       });
     });
 

--- a/tests/data-providers/token.dataProvider.ts
+++ b/tests/data-providers/token.dataProvider.ts
@@ -1,8 +1,24 @@
-/* eslint-disable max-len */
-export const getValidToken = (): string => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDU4ODcwMzIsInN0YXJ0RGF0ZSI6MTYwNjA4OTYwMCwiZW5kRGF0ZSI6MTYwODUwODc5OSwiZXhwIjoxNjA2NDkxODMyLCJpc3MiOiJodHRwczovL2ludC5jb25maXJtLW1vdC10ZXN0LWF2YWlsYWJpbGl0eS5zZXJ2aWNlLmdvdi51ayIsInN1YiI6Ijg1NjA5MGQxLWYyZGMtNGJiYy1hZDM2LThkMTQzODIzMzllMCJ9.Ylu2FSWGVLzL2viQfSnT_ahUvZYhUHJu9Jsy1A497cE';
-export const getExpiredToken = (): string => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDU4ODMyMDksInN0YXJ0RGF0ZSI6MTYwNjA4OTYwMCwiZW5kRGF0ZSI6MTYwODUwODc5OSwiZXhwIjoxNjA1Mjc4NDA5LCJpc3MiOiJodHRwczovL2ludC5jb25maXJtLW1vdC10ZXN0LWF2YWlsYWJpbGl0eS5zZXJ2aWNlLmdvdi51ayIsInN1YiI6Ijg1NjA5MGQxLWYyZGMtNGJiYy1hZDM2LThkMTQzODIzMzllMCJ9.fqzJrCkciLPcZssBDE1u3EtwhH6PgptiEbyWkByI4OA';
+import jwt from 'jsonwebtoken';
+
+export const getValidToken = (): string => tokenGenerator({algorithm:"HS256",issuer:"issuer","expiresIn":60 * 60,subject:"856090d1-f2dc-4bbc-ad36-8d14382339e0"},getJwtSecret(),{startDate:1619395199,endDate:1619395199});
+
+export const getExpiredToken = (): string => tokenGenerator({algorithm:"HS256",issuer:"issuer","expiresIn":0,subject:"856090d1-f2dc-4bbc-ad36-8d14382339e0"},getJwtSecret(),{startDate:1619395199,endDate:1619395199});
+
 export const getInvalidToken = (): string => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdGFydERhdGUiOjE2MDE5OTQxMDUsImVuZERhdGUiOjE2MDQ0MTMzMDUsImlzQXZhaWxhYmxlIjp0cnVlLCJpYXQiOjMxNTUzMjgwMCwiZXhwIjozMTYwNTEyMDAsImlzcyI6Imh0dHBzOi8vYm9vay1oZ3YtYnVzLXRyYWlsZXItbW90LnNlcnZpY2UuZ292LnVrIiwic3ViIjoiMUQ2MkFCRkQtRjAzRC00REUwLTlFRDUtOEMwMkY5N0M1NTNEIn0.xW2aFHfxhXDTkxXTtqAEdnHlyJtdFhDwXdRIPqLBIck';
-export const getSubMissingToken = () : string => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDU4ODk2MjYsInN0YXJ0RGF0ZSI6MTYwNjA4OTYwMCwiZW5kRGF0ZSI6MTYwODUwODc5OSwiZXhwIjoxNjA2NDk0NDI2LCJpc3MiOiJodHRwczovL2ludC5jb25maXJtLW1vdC10ZXN0LWF2YWlsYWJpbGl0eS5zZXJ2aWNlLmdvdi51ayJ9.Q0DDJ9D2kErVqGawRO7fK7vH8zsWLKvQcz4Kux711uc';
-export const getStartDateMissingToken = () : string => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDU4OTAyMTUsImVuZERhdGUiOjE2MDg1MDg3OTksImV4cCI6MTYwNjQ5NTAxNSwiaXNzIjoiaHR0cHM6Ly9pbnQuY29uZmlybS1tb3QtdGVzdC1hdmFpbGFiaWxpdHkuc2VydmljZS5nb3YudWsiLCJzdWIiOiI4NTYwOTBkMS1mMmRjLTRiYmMtYWQzNi04ZDE0MzgyMzM5ZTAifQ.GCjuTEqO8fZ9ytQ-mePzaaoimdlXnJuWnxrNvw47jCE';
-export const getEndDateMissingToken = () : string => 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpYXQiOjE2MDU4OTAzODQsInN0YXJ0RGF0ZSI6MTYwNjA4OTYwMCwiZXhwIjoxNjA2NDk1MTg0LCJpc3MiOiJodHRwczovL2ludC5jb25maXJtLW1vdC10ZXN0LWF2YWlsYWJpbGl0eS5zZXJ2aWNlLmdvdi51ayIsInN1YiI6Ijg1NjA5MGQxLWYyZGMtNGJiYy1hZDM2LThkMTQzODIzMzllMCJ9.ycNXufm2lKcd0lMatnxc7n6kFe_RMdEnYHgM_yj_e7A';
-export const getJwtSecret = (): string => 'hvtr4567';
+
+export const getSubMissingToken = () : string => tokenGenerator({algorithm:"HS256",issuer:"issuer","expiresIn":60 * 60},getJwtSecret(),{startDate:1619395199,endDate:1619395199});
+
+export const getStartDateMissingToken = () : string => tokenGenerator({algorithm:"HS256",issuer:"issuer","expiresIn":60 * 60,subject:"856090d1-f2dc-4bbc-ad36-8d14382339e0"},getJwtSecret(),{endDate:1619395199});
+
+export const getEndDateMissingToken = () : string => tokenGenerator({algorithm:"HS256",issuer:"issuer","expiresIn":60 * 60,subject:"856090d1-f2dc-4bbc-ad36-8d14382339e0"},getJwtSecret(),{startDate:1619395199});
+
+export const getJwtSecret = (): string => 'hvtr4567'
+
+interface payload {
+    startDate?:number,
+    endDate?:number
+}
+
+const tokenGenerator = (options:jwt.SignOptions, secret:string, payload?:payload, ):string => {
+   return jwt.sign(payload || {}, secret, options);
+}

--- a/tests/services/token.service.test.ts
+++ b/tests/services/token.service.test.ts
@@ -56,6 +56,7 @@ describe('Test token.service', () => {
 
     it('should return properly decoded token payload data when valid token provided', async () => {
       const validToken: string = getValidToken();
+      console.log(validToken);
       const req: Request = <Request> <unknown> { query: { token: validToken } };
 
       const result: TokenPayload = await tokenService.extractTokenPayload(req, true);
@@ -70,9 +71,9 @@ describe('Test token.service', () => {
         CiphertextBlob: Buffer.from(jwtSecret, 'base64'),
       });
       expect(result).toStrictEqual({
-        atfId: '856090d1-f2dc-4bbc-ad36-8d14382339e0',
-        endDate: '2020-12-20T23:59:59.000Z',
-        startDate: '2020-11-23T00:00:00.000Z',
+        "atfId": "856090d1-f2dc-4bbc-ad36-8d14382339e0",
+        "endDate": "2021-04-25T23:59:59.000Z",
+        "startDate": "2021-04-25T23:59:59.000Z",
       });
     });
 
@@ -84,9 +85,9 @@ describe('Test token.service', () => {
       const result: TokenPayload = await tokenService.extractTokenPayload(req, true);
 
       expect(result).toStrictEqual({
-        atfId: '856090d1-f2dc-4bbc-ad36-8d14382339e0',
-        endDate: '2020-12-20T23:59:59.000Z',
-        startDate: '2020-11-23T00:00:00.000Z',
+        "atfId": "856090d1-f2dc-4bbc-ad36-8d14382339e0",
+        "endDate": "2021-04-25T23:59:59.000Z",
+        "startDate": "2021-04-25T23:59:59.000Z",
       });
     });
 

--- a/tests/utils/viewHelper.util.test.ts
+++ b/tests/utils/viewHelper.util.test.ts
@@ -43,5 +43,13 @@ describe('Test viewHelper.util', () => {
       expect(utcToZonedTime).toHaveBeenCalledWith(new Date(someDateIsoString), timezone);
       expect(format).toHaveBeenCalledWith(new Date(someDateIsoString), 'EEEE d MMMM yyyy \'at\' h:mmaaaaa\'m\'');
     });
+    it('should handle invalid timezone presented to dateTimeZoneFormat', function(){
+      const someIsoDateFromInvalidUnixTimestamp = new Date(1619395199  * 1000).toISOString();
+      (utcToZonedTime as jest.Mock).mockImplementation(() => new Date(someIsoDateFromInvalidUnixTimestamp));
+      const formatDateTime: DateFunctionType = <DateFunctionType> nunjucks.getFilter('formatDateTime');
+      formatDateTime(someIsoDateFromInvalidUnixTimestamp); 
+      expect(format).toHaveBeenCalledWith(new Date(someIsoDateFromInvalidUnixTimestamp), 'EEEE d MMMM yyyy \'at\' h:mmaaaaa\'m\'')
+    })
   });
+  
 });

--- a/tests/utils/viewHelper.util.test.ts
+++ b/tests/utils/viewHelper.util.test.ts
@@ -39,7 +39,7 @@ describe('Test viewHelper.util', () => {
       const formatDateTime: DateFunctionType = <DateFunctionType> nunjucks.getFilter('formatDateTime');
 
       formatDateTime(someDateIsoString);
-
+    
       expect(utcToZonedTime).toHaveBeenCalledWith(new Date(someDateIsoString), timezone);
       expect(format).toHaveBeenCalledWith(new Date(someDateIsoString), 'EEEE d MMMM yyyy \'at\' h:mmaaaaa\'m\'');
     });
@@ -48,7 +48,8 @@ describe('Test viewHelper.util', () => {
       (utcToZonedTime as jest.Mock).mockImplementation(() => new Date(someIsoDateFromInvalidUnixTimestamp));
       const formatDateTime: DateFunctionType = <DateFunctionType> nunjucks.getFilter('formatDateTime');
       formatDateTime(someIsoDateFromInvalidUnixTimestamp); 
-      expect(format).toHaveBeenCalledWith(new Date(someIsoDateFromInvalidUnixTimestamp), 'EEEE d MMMM yyyy \'at\' h:mmaaaaa\'m\'')
+      expect(format).toHaveBeenCalledWith(new Date(someIsoDateFromInvalidUnixTimestamp), 'EEEE d MMMM yyyy \'at\' h:mmaaaaa\'m\'');
+      
     })
   });
   


### PR DESCRIPTION
## Description

- Update the unit tests for date and token handling.
- Amend to remove the expired token in test.
- Found that if the returned atf from the db doesn't have any
availability data, the template fails to render and blows up
- Also found the dates displayed on the page were incorrect as
the last updated dates were displayed - not the newly updated
dates
- To fix, the new availability dates should be set on the atf
model
- On templates, check if there's a value for last updated before
attempting to display it - if there's no value, no need to display
it
- Bug fix for #BL-12081

Related issue: BL-12070


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
